### PR TITLE
Various improvements

### DIFF
--- a/assets/package.json
+++ b/assets/package.json
@@ -1,7 +1,7 @@
 {
   "repository": {},
   "description": "Memoet assets files",
-  "license": "AGPL v3",
+  "license": "AGPL-3.0-only",
   "scripts": {
     "deploy": "NODE_ENV=production webpack --mode production",
     "watch": "webpack --mode development --watch-stdin"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -6,7 +6,7 @@ config :memoet, Memoet.Repo,
   password: "postgres",
   database: "memoet_dev",
   hostname: "localhost",
-  port: System.get_env("DATABASE_PORT") || 5433,
+  port: System.get_env("DATABASE_PORT") || 5432,
   show_sensitive_data_on_connection_error: true,
   pool_size: 10
 

--- a/lib/memoet_web/plug/root_layout_plug.ex
+++ b/lib/memoet_web/plug/root_layout_plug.ex
@@ -1,0 +1,7 @@
+defmodule MemoetWeb.Plugs.RootLayoutPlug do
+  def init(options), do: options
+
+  def call(conn, _opts) do
+    Phoenix.Controller.put_root_layout(conn, {MemoetWeb.LayoutView, :root})
+  end
+end

--- a/lib/memoet_web/router.ex
+++ b/lib/memoet_web/router.ex
@@ -12,7 +12,7 @@ defmodule MemoetWeb.Router do
     plug :accepts, ["html"]
     plug :fetch_session
     plug :fetch_flash
-    plug :put_root_layout, {MemoetWeb.LayoutView, :root}
+    plug MemoetWeb.Plugs.RootLayoutPlug
     plug :protect_from_forgery
     plug :put_secure_browser_headers
   end
@@ -114,12 +114,14 @@ defmodule MemoetWeb.Router do
     pow_routes()
     pow_extension_routes()
 
-    get "/community/:id/practice", MemoetWeb.DeckController, :public_practice, as: :community_deck
-    put "/community/:id/practice", MemoetWeb.DeckController, :public_answer, as: :community_deck
+    scope "/", MemoetWeb do
+      get "/community/:id/practice", DeckController, :public_practice, as: :community_deck
+      put "/community/:id/practice", DeckController, :public_answer, as: :community_deck
 
-    get "/community/:id", MemoetWeb.DeckController, :public_show, as: :community_deck
-    get "/community", MemoetWeb.DeckController, :public_index, as: :community_deck
-    get "/", MemoetWeb.PageController, :index
+      get "/community/:id", DeckController, :public_show, as: :community_deck
+      get "/community", DeckController, :public_index, as: :community_deck
+      get "/", PageController, :index
+    end
   end
 
   scope "/" do

--- a/mix.exs
+++ b/mix.exs
@@ -40,7 +40,7 @@ defmodule Memoet.MixProject do
   def application do
     [
       mod: {Memoet.Application, []},
-      extra_applications: [:logger, :runtime_tools, :cachex, :os_mon]
+      extra_applications: [:logger, :runtime_tools, :os_mon]
     ]
   end
 


### PR DESCRIPTION
Hi there! :wave:

Thanks for creating and open-sourcing memoet! It is pretty neat and I'm a huge fan of SRS (I use Anki as a daily practice). I was poking around in Memoet and saw a few things that seemed like they could be improved so I rolled them up in a PR. Please let me know if you'd prefer them broken up into multiple PR's or have any questions about the changes.

Remove :cachex from `:extra_applications` (dependencies automatically get started and don't need to be added to this list)

Fix Postgres default port (https://www.postgresql.org/docs/10/app-postgres.html)

Change package.json to be a valid SPDX license. Fixes this warning during `npm install`:

> npm WARN assets license should be a valid SPDX license expression

List of valid SPDX licenses: https://spdx.org/licenses/

The other option for an AGPL SPDX license is: `AGPL-3.0-or-later`

Note: I didn't update package-lock.json because I ended up with a 50+ line change after running `npm install` (and would've caused likely merge conflicts)

Fix excess recompilation dependencies in Router:
- Move the `put_root_layout` call in a separate plug
  - This way the router does not have a compile-time dependency on `MemoetWeb.LayoutView`, which is important because the layout view has many runtime dependencies
- Move the community and `PageController` routes to be under a scope
  - This prevents the router from having a compile-time dependency on `DeckController` and `PageController`

`router.ex` compilation dependencies before (via https://depviz.jasonaxelson.com) was recompiled when 61 other files were changed:
![Screenshot 2021-06-05 08 56 30](https://user-images.githubusercontent.com/9973/120904395-d1a06880-c5e7-11eb-8205-53da108dc1c0.png)

After this change `router.ex` is recompiled only when 5 other files are changed:
![Screenshot 2021-06-05 08 58 54](https://user-images.githubusercontent.com/9973/120904439-09a7ab80-c5e8-11eb-8bb7-542958490707.png)

I believe it is possible to remove the compile-time dependency on `api_auth_error_handler.ex` as well but I have not removed it for now.
